### PR TITLE
adds support for midigrid

### DIFF
--- a/lib/sequencers.lua
+++ b/lib/sequencers.lua
@@ -1,5 +1,6 @@
 local FXSequencer = include('timeparty/lib/FXSequencer')
 local MusicUtil = require 'musicutil'
+local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/mg_128" or grid
 local GRID = grid.connect()
 
 local voice = 1


### PR DESCRIPTION
I believe this adds Midigrid support safely so that if the library is not present, timeparty will fall back to the Monome grid library.
I verified that the script loads and LP Mini MK3 works when midigrid is present, and that the script loads correctly when the midigrid lib is not installed. However, i don't have a Monome Grid to test that it works as expected with this change.
Also, maybe you just don't want to support midigrid and that's ok too :)